### PR TITLE
Update to use formerr rather then state ErrorMessage

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -104,7 +104,8 @@ func (p Proxy) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 
 				// Check if the reply is correct; if not return FormErr.
 				if !state.Match(reply) {
-					formerr := state.ErrorMessage(dns.RcodeFormatError)
+					formerr := new(dns.Msg)
+					formerr.SetRcode(state.Req, dns.RcodeFormatError)
 					w.WriteMsg(formerr)
 					return 0, taperr
 				}


### PR DESCRIPTION
Looks to resolve the inability to install plugin in 1.5 [issue 2](https://github.com/coredns/proxy/issues/2)